### PR TITLE
Making Pictures smaller

### DIFF
--- a/app/components/Image.tsx
+++ b/app/components/Image.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import defaultRandomImage from "~/lib/defaultImagesList";
+
+interface ImageProps {
+  image: Record<string, any> | null;
+}
+
+export const Image = ({ image }: ImageProps) => {
+  if (!image) {
+    const src = defaultRandomImage();
+    // rendering a random default image since the API has reached its max quota
+    return (
+      <img
+        alt="theoneliner"
+        src={src}
+        className="w-full object-cover h-screen absolute top-0 left-0 z-0"
+      />
+    );
+  }
+  // rendering an actual random image from the API.
+  return (
+    <img
+      alt="theoneliner"
+      src={image.urls.regular}
+      className="w-full object-cover h-screen absolute top-0 left-0 z-0"
+    />
+  );
+};

--- a/app/lib/defaultImagesList.ts
+++ b/app/lib/defaultImagesList.ts
@@ -1,0 +1,20 @@
+export const images = [
+  "https://source.unsplash.com/black-and-gray-microphone-on-black-stand-QrqeusbpFMM",
+  "https://source.unsplash.com/man-in-red-knit-cap-and-yellow-and-black-plaid-dress-shirt-holding-microphone-9ujdLC6sOaM",
+  "https://source.unsplash.com/person-standing-on-stage-ub77xN37pNs",
+  "https://source.unsplash.com/man-in-black-shirt-singing-on-stage-NBRNK4XC1k8",
+  "https://source.unsplash.com/laugh-neon-signage-imlD5dbcLM4",
+  "https://source.unsplash.com/man-in-red-and-white-plaid-button-up-shirt-holding-microphone-9gvDZCiA6Dk",
+  "https://source.unsplash.com/white-and-black-i-love-you-print-on-gray-concrete-wall-q73jLftKN-A",
+  "https://source.unsplash.com/a-person-sitting-on-a-couch-with-a-laptop-X1GZqv-F7Tw",
+  "https://source.unsplash.com/a-couple-of-women-sitting-next-to-each-other-eating-a-slice-of-pizza-DTL4gISnmkM",
+  "https://source.unsplash.com/smiling-woman-wearing-pink-sweater-ZiBSfB6KEFA",
+  "https://source.unsplash.com/three-people-sitting-in-front-of-table-laughing-together-g1Kr4Ozfoac",
+  "https://source.unsplash.com/a-group-of-people-standing-next-to-each-other-d0JuQdnRW7Y",
+  "https://source.unsplash.com/attractive-young-woman-with-curly-hair-using-her-touch-screen-mobile-cell-phone-by-the-fountain-e2kKxF0LE8A",
+  "https://source.unsplash.com/man-sitting-beside-two-woman-on-gray-surface-rwF_pJRWhAI",
+];
+
+export default function defaultRandomImage() {
+  return images.at(Math.floor(Math.random() * images.length));
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -31,7 +31,7 @@ export default function App() {
         <div className="w-full">
           <div className="fixed top-0 w-full text-lg bg-gradient-to-r from-indigo-800 to-indigo-300 flex justify-between items-center z-20 p-1 text-slate-800">
             <h3 className="text-2xl text-white">The oneliner</h3>
-            <p>A random joke comedian</p>
+            <p className="hidden md:block">A random joke comedian</p>
             <a
               href="https://github.com/alexserver/theoneliner"
               target="_blank"

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -2,6 +2,7 @@ import { unsplash } from "~/lib/unsplash.server";
 import { json, type MetaFunction } from "@remix-run/node";
 import { Form, useLoaderData } from "@remix-run/react";
 import { prisma } from "~/lib/db.server";
+import { Image } from "~/components/Image";
 
 export const meta: MetaFunction = () => {
   return [
@@ -10,7 +11,7 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-const fetchRandomImage = async (): Promise<Record<string, any> | null> => {
+const fetchImage = async (): Promise<Record<string, any> | null> => {
   try {
     const result = await unsplash.photos.getRandom({
       collectionIds: [
@@ -34,44 +35,37 @@ const fetchRandomImage = async (): Promise<Record<string, any> | null> => {
   return null;
 };
 
-async function getJoke() {
-  let joke = null;
+async function fetchJoke() {
   try {
     const count = await prisma.joke.count();
     const jokes = await prisma.joke.findMany({
       take: 1,
       skip: Math.floor(Math.random() * count),
     });
-    joke = jokes.at(0);
+    if (jokes.length > 0) {
+      return jokes.at(0);
+    }
+    return null;
   } catch (err) {
     console.error("Prisma failed to fetch joke ", err);
+    return null;
   }
-  return joke;
 }
 
 export async function loader() {
-  const joke = await getJoke();
-  const image = await fetchRandomImage();
-  // console.log({ joke });
-  // console.log({ image });
+  const joke = await fetchJoke();
+  const image = await fetchImage();
   return json({ joke, image });
 }
 
 export default function Index() {
   const { joke, image } = useLoaderData<typeof loader>();
-  if (!joke || !image) {
-    return <div>No data</div>;
-  }
 
   return (
     <>
-      <img
-        alt="laugh"
-        src={image ? image.urls.full : ""}
-        className="w-full object-cover h-screen absolute top-0 left-0 z-0"
-      />
+      <Image image={image} />
       <h1 className="text-3xl text-center text-white bg-slate-900 rounded-xl z-10 p-4 opacity-80 font-bold max-w-3xl">
-        {joke.content}
+        {joke ? joke.content : "Oops I'm not feeling funny enough"}
       </h1>
       <Form method="get" className="z-10">
         <button

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "remixv2",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^5.7.1",
         "@remix-run/css-bundle": "^2.4.1",


### PR DESCRIPTION
## Changes:

- making the picture to be rendered smaller (I was rendering the full size 6Mb, now it's the regular one 200Kb)
- adding an `Image` component the will catch whether the pic coming from Unsplash API is `null`, then it renders a random pic from a default list of laughing people from unsplash. Both collections are in Unsplash but the main one comes from the API with tons of data, while the fallback one only contains the urls for regular pic size.
- deleting some element from mobile view


## Screens

![screencapture-localhost-3000-2024-01-02-15_28_24](https://github.com/alexserver/theoneliner/assets/694404/22b2c36b-7085-42d7-a468-44ecc9bffa55)
![screencapture-localhost-3000-2024-01-02-15_27_57](https://github.com/alexserver/theoneliner/assets/694404/11e4f2a8-dd6f-400f-ac30-1cc0d215ce32)
