### PR TITLE
Adding unsplash author link

### DIFF
--- a/app/components/Image.tsx
+++ b/app/components/Image.tsx
@@ -7,23 +7,20 @@ interface ImageProps {
 }
 
 export const Image = ({ image }: ImageProps) => {
-  if (!image) {
-    const src = defaultRandomImage();
-    // rendering a random default image since the API has reached its max quota
-    return (
-      <img
-        alt="theoneliner"
-        src={src}
-        className="w-full object-cover h-screen absolute top-0 left-0 z-0"
-      />
-    );
-  }
-  // rendering an actual random image from the API.
+  const img = image !== null ? image : defaultRandomImage();
+  const src = img.urls?.regular;
+  const author = img.user?.name;
+  const link = img.links?.html;
   return (
-    <img
-      alt="theoneliner"
-      src={image.urls.regular}
-      className="w-full object-cover h-screen absolute top-0 left-0 z-0"
-    />
+    <div className="w-full h-screen absolute top-0 left-0 z-0">
+      <img alt="theoneliner" src={src} className="w-full h-full object-cover" />
+      <a
+        href={link}
+        target="_blank"
+        className="absolute bottom-0 w-full text-sm text-right bg-slate-900/50 hover:bg-slate-900/90 text-white px-4 py-2"
+      >
+        Photo by {author}
+      </a>
+    </div>
   );
 };

--- a/app/lib/defaultImagesList.ts
+++ b/app/lib/defaultImagesList.ts
@@ -1,20 +1,272 @@
+// export const imgs = [
+//   "https://source.unsplash.com/black-and-gray-microphone-on-black-stand-QrqeusbpFMM",
+//   "https://source.unsplash.com/man-in-red-knit-cap-and-yellow-and-black-plaid-dress-shirt-holding-microphone-9ujdLC6sOaM",
+//   "https://source.unsplash.com/person-standing-on-stage-ub77xN37pNs",
+//   "https://source.unsplash.com/man-in-black-shirt-singing-on-stage-NBRNK4XC1k8",
+//   "https://source.unsplash.com/laugh-neon-signage-imlD5dbcLM4",
+//   "https://source.unsplash.com/man-in-red-and-white-plaid-button-up-shirt-holding-microphone-9gvDZCiA6Dk",
+//   "https://source.unsplash.com/white-and-black-i-love-you-print-on-gray-concrete-wall-q73jLftKN-A",
+//   "https://source.unsplash.com/a-person-sitting-on-a-couch-with-a-laptop-X1GZqv-F7Tw",
+//   "https://source.unsplash.com/a-couple-of-women-sitting-next-to-each-other-eating-a-slice-of-pizza-DTL4gISnmkM",
+//   "https://source.unsplash.com/smiling-woman-wearing-pink-sweater-ZiBSfB6KEFA",
+//   "https://source.unsplash.com/three-people-sitting-in-front-of-table-laughing-together-g1Kr4Ozfoac",
+//   "https://source.unsplash.com/a-group-of-people-standing-next-to-each-other-d0JuQdnRW7Y",
+//   "https://source.unsplash.com/attractive-young-woman-with-curly-hair-using-her-touch-screen-mobile-cell-phone-by-the-fountain-e2kKxF0LE8A",
+//   "https://source.unsplash.com/man-sitting-beside-two-woman-on-gray-surface-rwF_pJRWhAI",
+// ];
+
 export const images = [
-  "https://source.unsplash.com/black-and-gray-microphone-on-black-stand-QrqeusbpFMM",
-  "https://source.unsplash.com/man-in-red-knit-cap-and-yellow-and-black-plaid-dress-shirt-holding-microphone-9ujdLC6sOaM",
-  "https://source.unsplash.com/person-standing-on-stage-ub77xN37pNs",
-  "https://source.unsplash.com/man-in-black-shirt-singing-on-stage-NBRNK4XC1k8",
-  "https://source.unsplash.com/laugh-neon-signage-imlD5dbcLM4",
-  "https://source.unsplash.com/man-in-red-and-white-plaid-button-up-shirt-holding-microphone-9gvDZCiA6Dk",
-  "https://source.unsplash.com/white-and-black-i-love-you-print-on-gray-concrete-wall-q73jLftKN-A",
-  "https://source.unsplash.com/a-person-sitting-on-a-couch-with-a-laptop-X1GZqv-F7Tw",
-  "https://source.unsplash.com/a-couple-of-women-sitting-next-to-each-other-eating-a-slice-of-pizza-DTL4gISnmkM",
-  "https://source.unsplash.com/smiling-woman-wearing-pink-sweater-ZiBSfB6KEFA",
-  "https://source.unsplash.com/three-people-sitting-in-front-of-table-laughing-together-g1Kr4Ozfoac",
-  "https://source.unsplash.com/a-group-of-people-standing-next-to-each-other-d0JuQdnRW7Y",
-  "https://source.unsplash.com/attractive-young-woman-with-curly-hair-using-her-touch-screen-mobile-cell-phone-by-the-fountain-e2kKxF0LE8A",
-  "https://source.unsplash.com/man-sitting-beside-two-woman-on-gray-surface-rwF_pJRWhAI",
+  {
+    id: "-5Vl9oimYlU",
+    slug: "grayscale-photo-of-man-making-silly-face--5Vl9oimYlU",
+    width: 3008,
+    height: 2000,
+    description: "Man laughing. Authentic black and white portrait.",
+    urls: {
+      raw: "https://images.unsplash.com/photo-1577202214328-c04b77cefb5d?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAxNDZ8&ixlib=rb-4.0.3",
+      full: "https://images.unsplash.com/photo-1577202214328-c04b77cefb5d?crop=entropy&cs=srgb&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAxNDZ8&ixlib=rb-4.0.3&q=85",
+      regular:
+        "https://images.unsplash.com/photo-1577202214328-c04b77cefb5d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAxNDZ8&ixlib=rb-4.0.3&q=80&w=1080",
+      small:
+        "https://images.unsplash.com/photo-1577202214328-c04b77cefb5d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAxNDZ8&ixlib=rb-4.0.3&q=80&w=400",
+      thumb:
+        "https://images.unsplash.com/photo-1577202214328-c04b77cefb5d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAxNDZ8&ixlib=rb-4.0.3&q=80&w=200",
+      small_s3:
+        "https://s3.us-west-2.amazonaws.com/images.unsplash.com/small/photo-1577202214328-c04b77cefb5d",
+    },
+    links: {
+      self: "https://api.unsplash.com/photos/grayscale-photo-of-man-making-silly-face--5Vl9oimYlU",
+      html: "https://unsplash.com/photos/grayscale-photo-of-man-making-silly-face--5Vl9oimYlU",
+      download:
+        "https://unsplash.com/photos/-5Vl9oimYlU/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAxNDZ8",
+      download_location:
+        "https://api.unsplash.com/photos/-5Vl9oimYlU/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAxNDZ8",
+    },
+    user: {
+      id: "fOkQ5s4HYpM",
+      updated_at: "2023-10-02T00:43:29Z",
+      username: "denisagati",
+      name: "Denis Agati",
+      first_name: "Denis",
+      last_name: "Agati",
+      twitter_username: null,
+      portfolio_url: "https://www.facebook.com/redeko",
+      bio: null,
+      location: "Moldova, Chisinau.",
+      instagram_username: "denisagati",
+      total_collections: 0,
+      total_likes: 0,
+      total_photos: 68,
+      total_promoted_photos: 2,
+      accepted_tos: true,
+      for_hire: false,
+    },
+  },
+  {
+    id: "9euorpmZbbk",
+    slug: "a-black-and-white-photo-of-a-woman-smiling-9euorpmZbbk",
+    promoted_at: null,
+    width: 2667,
+    height: 4000,
+    alt_description: "a black and white photo of a woman smiling",
+    breadcrumbs: [],
+    urls: {
+      raw: "https://images.unsplash.com/photo-1563101883-9248c8886ab8?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAzNjF8&ixlib=rb-4.0.3",
+      full: "https://images.unsplash.com/photo-1563101883-9248c8886ab8?crop=entropy&cs=srgb&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAzNjF8&ixlib=rb-4.0.3&q=85",
+      regular:
+        "https://images.unsplash.com/photo-1563101883-9248c8886ab8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAzNjF8&ixlib=rb-4.0.3&q=80&w=1080",
+      small:
+        "https://images.unsplash.com/photo-1563101883-9248c8886ab8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAzNjF8&ixlib=rb-4.0.3&q=80&w=400",
+      thumb:
+        "https://images.unsplash.com/photo-1563101883-9248c8886ab8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAzNjF8&ixlib=rb-4.0.3&q=80&w=200",
+      small_s3:
+        "https://s3.us-west-2.amazonaws.com/images.unsplash.com/small/photo-1563101883-9248c8886ab8",
+    },
+    links: {
+      self: "https://api.unsplash.com/photos/a-black-and-white-photo-of-a-woman-smiling-9euorpmZbbk",
+      html: "https://unsplash.com/photos/a-black-and-white-photo-of-a-woman-smiling-9euorpmZbbk",
+      download:
+        "https://unsplash.com/photos/9euorpmZbbk/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAzNjF8",
+      download_location:
+        "https://api.unsplash.com/photos/9euorpmZbbk/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDAzNjF8",
+    },
+    user: {
+      id: "REmDvW4ictg",
+      updated_at: "2023-11-27T19:26:35Z",
+      username: "anastasiavitph",
+      name: "Anastasia Vityukova",
+      first_name: "Anastasia",
+      last_name: "Vityukova",
+      twitter_username: null,
+      portfolio_url: null,
+      bio: null,
+      location: "Russia",
+      instagram_username: "anastasiavityukova__",
+      total_collections: 0,
+      total_likes: 44,
+      total_photos: 362,
+      total_promoted_photos: 18,
+      accepted_tos: true,
+      for_hire: true,
+    },
+  },
+  {
+    id: "wN1CH6Ferbg",
+    slug: "a-dim-shot-of-two-chairs-and-microphone-stands-on-an-empty-stage-wN1CH6Ferbg",
+    created_at: "2014-10-02T20:38:01Z",
+    updated_at: "2024-01-02T05:00:06Z",
+    promoted_at: "2014-10-02T20:38:01Z",
+    width: 5184,
+    height: 3456,
+    description: "Empty stage at night",
+    alt_description:
+      "A dim shot of two chairs and microphone stands on an empty stage",
+    urls: {
+      raw: "https://images.unsplash.com/uploads/1412282232015a06e258a/4bdd2a58?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA0NjV8&ixlib=rb-4.0.3",
+      full: "https://images.unsplash.com/uploads/1412282232015a06e258a/4bdd2a58?crop=entropy&cs=srgb&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA0NjV8&ixlib=rb-4.0.3&q=85",
+      regular:
+        "https://images.unsplash.com/uploads/1412282232015a06e258a/4bdd2a58?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA0NjV8&ixlib=rb-4.0.3&q=80&w=1080",
+      small:
+        "https://images.unsplash.com/uploads/1412282232015a06e258a/4bdd2a58?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA0NjV8&ixlib=rb-4.0.3&q=80&w=400",
+      thumb:
+        "https://images.unsplash.com/uploads/1412282232015a06e258a/4bdd2a58?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA0NjV8&ixlib=rb-4.0.3&q=80&w=200",
+      small_s3:
+        "https://s3.us-west-2.amazonaws.com/images.unsplash.com/small/uploads/1412282232015a06e258a/4bdd2a58",
+    },
+    links: {
+      self: "https://api.unsplash.com/photos/a-dim-shot-of-two-chairs-and-microphone-stands-on-an-empty-stage-wN1CH6Ferbg",
+      html: "https://unsplash.com/photos/a-dim-shot-of-two-chairs-and-microphone-stands-on-an-empty-stage-wN1CH6Ferbg",
+      download:
+        "https://unsplash.com/photos/wN1CH6Ferbg/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA0NjV8",
+      download_location:
+        "https://api.unsplash.com/photos/wN1CH6Ferbg/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA0NjV8",
+    },
+    user: {
+      id: "h9PaxwUaQ4E",
+      updated_at: "2023-09-12T11:20:56Z",
+      username: "hpeurane",
+      name: "Hannu-Pekka Peuranen",
+      first_name: "Hannu-Pekka",
+      last_name: "Peuranen",
+      twitter_username: "hpeurane",
+      portfolio_url: "https://twitter.com/hpeurane",
+      bio: null,
+      location: null,
+      links: [Object],
+      profile_image: [Object],
+      instagram_username: null,
+      total_collections: 0,
+      total_likes: 0,
+      total_photos: 6,
+      total_promoted_photos: 1,
+      accepted_tos: false,
+      for_hire: false,
+      social: [Object],
+    },
+  },
+  {
+    id: "mEZ3PoFGs_k",
+    slug: "closeup-photography-of-woman-smiling-mEZ3PoFGs_k",
+    created_at: "2017-05-14T19:30:13Z",
+    updated_at: "2024-01-02T21:01:55Z",
+    promoted_at: "2017-05-15T08:35:06Z",
+    width: 3744,
+    height: 5616,
+    description: "Happy daughter",
+    alt_description: "closeup photography of woman smiling",
+    urls: {
+      raw: "https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA1MzZ8&ixlib=rb-4.0.3",
+      full: "https://images.unsplash.com/photo-1494790108377-be9c29b29330?crop=entropy&cs=srgb&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA1MzZ8&ixlib=rb-4.0.3&q=85",
+      regular:
+        "https://images.unsplash.com/photo-1494790108377-be9c29b29330?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA1MzZ8&ixlib=rb-4.0.3&q=80&w=1080",
+      small:
+        "https://images.unsplash.com/photo-1494790108377-be9c29b29330?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA1MzZ8&ixlib=rb-4.0.3&q=80&w=400",
+      thumb:
+        "https://images.unsplash.com/photo-1494790108377-be9c29b29330?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA1MzZ8&ixlib=rb-4.0.3&q=80&w=200",
+      small_s3:
+        "https://s3.us-west-2.amazonaws.com/images.unsplash.com/small/photo-1494790108377-be9c29b29330",
+    },
+    links: {
+      self: "https://api.unsplash.com/photos/closeup-photography-of-woman-smiling-mEZ3PoFGs_k",
+      html: "https://unsplash.com/photos/closeup-photography-of-woman-smiling-mEZ3PoFGs_k",
+      download:
+        "https://unsplash.com/photos/mEZ3PoFGs_k/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA1MzZ8",
+      download_location:
+        "https://api.unsplash.com/photos/mEZ3PoFGs_k/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDA1MzZ8",
+    },
+    user: {
+      id: "s_l4ZYCw4EY",
+      updated_at: "2023-12-19T19:24:05Z",
+      username: "michaeldam",
+      name: "Michael Dam",
+      first_name: "Michael",
+      last_name: "Dam",
+      twitter_username: "Michael__Dam",
+      portfolio_url: null,
+      bio: null,
+      location: null,
+      instagram_username: null,
+      total_collections: 2,
+      total_likes: 11,
+      total_photos: 5,
+      total_promoted_photos: 3,
+      accepted_tos: false,
+      for_hire: false,
+    },
+  },
+  {
+    id: "HRZUzoX1e6w",
+    slug: "woman-smiling-while-standing-in-garden-HRZUzoX1e6w",
+    created_at: "2015-12-16T20:23:36Z",
+    updated_at: "2024-01-02T15:06:08Z",
+    promoted_at: "2015-12-16T20:23:36Z",
+    width: 3435,
+    height: 5153,
+    description: null,
+    alt_description: "woman smiling while standing in garden",
+    urls: {
+      raw: "https://images.unsplash.com/photo-1450297350677-623de575f31c?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDI1NjB8&ixlib=rb-4.0.3",
+      full: "https://images.unsplash.com/photo-1450297350677-623de575f31c?crop=entropy&cs=srgb&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDI1NjB8&ixlib=rb-4.0.3&q=85",
+      regular:
+        "https://images.unsplash.com/photo-1450297350677-623de575f31c?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDI1NjB8&ixlib=rb-4.0.3&q=80&w=1080",
+      small:
+        "https://images.unsplash.com/photo-1450297350677-623de575f31c?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDI1NjB8&ixlib=rb-4.0.3&q=80&w=400",
+      thumb:
+        "https://images.unsplash.com/photo-1450297350677-623de575f31c?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDI1NjB8&ixlib=rb-4.0.3&q=80&w=200",
+      small_s3:
+        "https://s3.us-west-2.amazonaws.com/images.unsplash.com/small/photo-1450297350677-623de575f31c",
+    },
+    links: {
+      self: "https://api.unsplash.com/photos/woman-smiling-while-standing-in-garden-HRZUzoX1e6w",
+      html: "https://unsplash.com/photos/woman-smiling-while-standing-in-garden-HRZUzoX1e6w",
+      download:
+        "https://unsplash.com/photos/HRZUzoX1e6w/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDI1NjB8",
+      download_location:
+        "https://api.unsplash.com/photos/HRZUzoX1e6w/download?ixid=M3w1NDY2Mzl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3MDQyNDI1NjB8",
+    },
+    user: {
+      id: "5z4oU7VzD3g",
+      updated_at: "2023-12-30T06:56:01Z",
+      username: "brookecagle",
+      name: "Brooke Cagle",
+      first_name: "Brooke",
+      last_name: "Cagle",
+      twitter_username: null,
+      portfolio_url: "https://www.tributarystudio.co/",
+      bio: "Founder of Tributary Studio, Top 25 Viewed/Downloaded on Unsplash, Arkansas Unsplash Ambassador  ✕  Clients Include: Google, Samsung, Walmart, Aerie, Nylon Magazine. For Donations  –  Venmo:  @tributarystudio  |  Paypal: @brookecagle",
+      location: "Arkansas",
+      instagram_username: "tributarystudio.co",
+      total_collections: 19,
+      total_likes: 522,
+      total_photos: 1269,
+      total_promoted_photos: 405,
+      accepted_tos: true,
+      for_hire: true,
+    },
+  },
 ];
 
-export default function defaultRandomImage() {
-  return images.at(Math.floor(Math.random() * images.length));
+export default function defaultRandomImage(): Record<string, any> {
+  const index = Math.floor(Math.random() * images.length);
+  return images.at(index) ?? images[0];
 }


### PR DESCRIPTION
## Changes

- Adding a more complex array of fallback image list. With different urls and author information
- Showing a link that will redirect the user to the photo author, this is to comply with Unsplash API license.

## Screens

![screencapture-localhost-3000-2024-01-02-18_48_07](https://github.com/alexserver/theoneliner/assets/694404/555bc1c6-0149-47ff-ac0b-51ca92bd7860)
![screencapture-localhost-3000-2024-01-02-18_47_48](https://github.com/alexserver/theoneliner/assets/694404/ada2dc5c-7e81-4fc5-88fc-5127b482a2ac)